### PR TITLE
Add Flask signup app

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,4 @@
+ADMIN_USERNAME=admin
+ADMIN_PASSWORD=secret
+DATABASE_URI=sqlite:///app.db
+FLASK_SECRET_KEY=change_me

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+.env
+app.db
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,25 @@
-# weihnachtsessen-anmeldung
-Anmeldeseite für ein Weihnachtsessen
+# Weihnachtsessen Anmeldung
+
+Dies ist eine kleine Flask-Anwendung zur Anmeldung zum Weihnachtsessen des DARC Ortsverbands Essen-Mitte L11.
+
+## Voraussetzungen
+
+- Python 3
+- Abhängigkeiten aus `requirements.txt`
+
+```bash
+pip install -r requirements.txt
+```
+
+## Starten der Anwendung
+
+1. Erstelle eine `.env` Datei nach dem Vorbild von `.env.sample` und passe die Zugangsdaten an.
+2. Starte die Anwendung mit:
+
+```bash
+python app.py
+```
+
+Die Webseite ist anschließend unter `http://localhost:5000` erreichbar.
+
+Der Adminbereich befindet sich unter `http://localhost:5000/admin` und ist mit dem in der `.env` Datei angegebenen Benutzernamen und Passwort geschützt.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+Flask_SQLAlchemy
+python-dotenv

--- a/static/script.js
+++ b/static/script.js
@@ -1,0 +1,13 @@
+document.addEventListener('DOMContentLoaded', function() {
+  function update() {
+    const value = parseInt(document.getElementById('additional').value || '0');
+    const count = 1 + value;
+    document.getElementById('person-count').innerText =
+      'Anmeldung für ' + count + ' Person' + (count > 1 ? 'en' : '');
+  }
+  const input = document.getElementById('additional');
+  if (input) {
+    input.addEventListener('input', update);
+    update();
+  }
+});

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Adminbereich</h1>
+<p>Gesamte angemeldete Personen: {{ total_persons }}</p>
+<table class="table">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Rufzeichen</th>
+      <th>Zusätzliche Personen</th>
+      <th>Gesamt</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for s in signups %}
+    <tr>
+      <td>{{ s.name }}</td>
+      <td>{{ s.callsign or '' }}</td>
+      <td>{{ s.additional }}</td>
+      <td>{{ 1 + s.additional }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8">
+  <title>DARC Essen-Mitte L11 Weihnachtsessen</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body class="container my-4">
+  {% block content %}{% endblock %}
+  <script src="{{ url_for('static', filename='script.js') }}"></script>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Weihnachtsessen 2025 Anmeldung</h1>
+<p>Das Weihnachtsessen findet am Freitag, 12.12.2025 um 18 Uhr im Parkrestaurant Spindelmann, Palmbuschweg 57, 45326 Essen-Altenessen, statt.</p>
+<p>Bisher angemeldete Personen: {{ total_persons }}</p>
+<form method="post">
+  <div class="mb-3">
+    <label for="name" class="form-label">Name *</label>
+    <input type="text" id="name" name="name" class="form-control" required>
+  </div>
+  <div class="mb-3">
+    <label for="callsign" class="form-label">Rufzeichen</label>
+    <input type="text" id="callsign" name="callsign" class="form-control">
+  </div>
+  <div class="mb-3">
+    <label for="additional" class="form-label">Zusätzliche Personen</label>
+    <input type="number" id="additional" name="additional" class="form-control" min="0" max="5" value="0">
+  </div>
+  <p id="person-count">Anmeldung für 1 Person</p>
+  <button type="submit" class="btn btn-primary">Anmelden</button>
+</form>
+{% if message %}
+<div class="alert alert-success mt-3">{{ message }}</div>
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- create a Flask application to handle dinner signups
- show total number of registered persons on the main page
- admin section secured via credentials from `.env`
- add templates and JavaScript for live person count
- document setup and provide `.env.sample`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e74153af48321aef5b9265a908b53