### PR TITLE
Improve signup page styling

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,0 +1,19 @@
+body {
+  background-color: #f0f8ff;
+  color: #003366;
+}
+
+h1, h2, h3, h4, h5 {
+  color: #0059b3;
+}
+
+.btn-primary {
+  background-color: #007bff;
+  border-color: #007bff;
+}
+
+.alert-success {
+  background-color: #cce5ff;
+  border-color: #b8daff;
+  color: #004085;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <title>DARC Essen-Mitte L11 Weihnachtsessen</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+  <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body class="container my-4">
   {% block content %}{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -2,6 +2,7 @@
 {% block content %}
 <h1>Weihnachtsessen 2025 Anmeldung</h1>
 <p>Das Weihnachtsessen findet am Freitag, 12.12.2025 um 18 Uhr im Parkrestaurant Spindelmann, Palmbuschweg 57, 45326 Essen-Altenessen, statt.</p>
+<p>Anmeldeschluss ist Freitag, 17.10.2025 (8 Wochen vor dem Termin). Diese Anmeldung ist verbindlich.</p>
 <p>Bisher angemeldete Personen: {{ total_persons }}</p>
 <form method="post">
   <div class="mb-3">


### PR DESCRIPTION
## Summary
- add blue-themed styling
- load custom stylesheet
- show binding signup notice and signup deadline

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_686e760781e083219e173f72fb2e2d61