### PR TITLE
Disable signups after 2025-10-18 and add footer

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -8,6 +8,9 @@
 </head>
 <body class="container my-4">
   {% block content %}{% endblock %}
+  <footer class="text-center mt-4">
+    <p>&copy; {{ current_year }} - Erik Schauer - <a href="mailto:do1ffe@darc.de">do1ffe@darc.de</a></p>
+  </footer>
   <script src="{{ url_for('static', filename='script.js') }}"></script>
 </body>
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,8 +18,11 @@
     <input type="number" id="additional" name="additional" class="form-control" min="0" max="5" value="0">
   </div>
   <p id="person-count">Anmeldung für 1 Person</p>
-  <button type="submit" class="btn btn-primary">Anmelden</button>
+  <button type="submit" class="btn btn-primary" {% if not signup_allowed %}disabled{% endif %}>Anmelden</button>
 </form>
+{% if not signup_allowed %}
+<div class="alert alert-warning mt-3">Die Anmeldung ist geschlossen.</div>
+{% endif %}
 {% if message %}
 <div class="alert alert-success mt-3">{{ message }}</div>
 {% endif %}


### PR DESCRIPTION
## Summary
- show current year footer with contact
- close registration after the deadline
- disable the signup button when registration is closed

## Testing
- `python -m py_compile app.py`
- `flake8 app.py templates/*.html static/*.js static/*.css`

------
https://chatgpt.com/codex/tasks/task_e_686e77471168832192dca7569548e4d7