### PR TITLE
Update app to run on port 8086

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,6 @@ pip install -r requirements.txt
 python app.py
 ```
 
-Die Webseite ist anschließend unter `http://localhost:5000` erreichbar.
+Die Webseite ist anschließend unter `http://localhost:8086` erreichbar.
 
-Der Adminbereich befindet sich unter `http://localhost:5000/admin` und ist mit dem in der `.env` Datei angegebenen Benutzernamen und Passwort geschützt.
+Der Adminbereich befindet sich unter `http://localhost:8086/admin` und ist mit dem in der `.env` Datei angegebenen Benutzernamen und Passwort geschützt.

--- a/app.py
+++ b/app.py
@@ -89,4 +89,7 @@ def admin():
     return render_template('admin.html', signups=signups, total_persons=total)
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    # Listen on all interfaces to make the application reachable from outside
+    # the container or local machine. The port is changed to 8086 instead of
+    # Flask's default 5000.
+    app.run(debug=True, host='0.0.0.0', port=8086)


### PR DESCRIPTION
## Summary
- configure `app.run` to bind on `0.0.0.0` port `8086`
- update README to mention the new port

## Testing
- `pytest -q`
- `python app.py` *(fails: `before_first_request` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e7a891a9c8321ad5447a1d06059e3