### PR TITLE
Fix Flask 3 compatibility

### DIFF
--- a/app.py
+++ b/app.py
@@ -52,8 +52,11 @@ def requires_auth(f):
         return f(*args, **kwargs)
     return decorated
 
-@app.before_first_request
-def create_tables():
+
+# Ensure tables are created when the application starts. The `before_first_request`
+# decorator was removed in Flask 3, so we create the tables explicitly within an
+# application context at import time.
+with app.app_context():
     db.create_all()
 
 @app.route('/', methods=['GET', 'POST'])


### PR DESCRIPTION
## Summary
- remove `before_first_request` usage
- create database tables on startup within application context

## Testing
- `pip install -r requirements.txt`
- `python app.py` *(ran server to confirm no attribute error)*
- `pytest -q`
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_686e8063a82c832193e3e1c1197ae37b