### PR TITLE
Allow admins to modify signups

### DIFF
--- a/app.py
+++ b/app.py
@@ -91,6 +91,35 @@ def admin():
     total = total_persons()
     return render_template('admin.html', signups=signups, total_persons=total)
 
+
+@app.route('/admin/delete/<int:signup_id>', methods=['POST'])
+@requires_auth
+def delete_signup(signup_id: int):
+    """Delete a signup entry."""
+    signup = Signup.query.get_or_404(signup_id)
+    db.session.delete(signup)
+    db.session.commit()
+    return redirect(url_for('admin'))
+
+
+@app.route('/admin/edit/<int:signup_id>', methods=['GET', 'POST'])
+@requires_auth
+def edit_signup(signup_id: int):
+    """Edit an existing signup."""
+    signup = Signup.query.get_or_404(signup_id)
+    if request.method == 'POST':
+        signup.name = request.form.get('name')
+        signup.callsign = request.form.get('callsign')
+        additional = request.form.get('additional', '0')
+        try:
+            additional = int(additional)
+        except ValueError:
+            additional = 0
+        signup.additional = max(0, min(5, additional))
+        db.session.commit()
+        return redirect(url_for('admin'))
+    return render_template('edit.html', signup=signup)
+
 if __name__ == '__main__':
     # Listen on all interfaces to make the application reachable from outside
     # the container or local machine. The port is changed to 8086 instead of

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -9,6 +9,7 @@
       <th>Rufzeichen</th>
       <th>Zusätzliche Personen</th>
       <th>Gesamt</th>
+      <th>Aktionen</th>
     </tr>
   </thead>
   <tbody>
@@ -18,6 +19,12 @@
       <td>{{ s.callsign or '' }}</td>
       <td>{{ s.additional }}</td>
       <td>{{ 1 + s.additional }}</td>
+      <td>
+        <a href="{{ url_for('edit_signup', signup_id=s.id) }}" class="btn btn-sm btn-secondary me-1">Bearbeiten</a>
+        <form method="post" action="{{ url_for('delete_signup', signup_id=s.id) }}" style="display:inline-block">
+          <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Eintrag wirklich löschen?');">Löschen</button>
+        </form>
+      </td>
     </tr>
     {% endfor %}
   </tbody>

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Eintrag bearbeiten</h1>
+<form method="post">
+  <div class="mb-3">
+    <label for="name" class="form-label">Name *</label>
+    <input type="text" id="name" name="name" class="form-control" value="{{ signup.name }}" required>
+  </div>
+  <div class="mb-3">
+    <label for="callsign" class="form-label">Rufzeichen</label>
+    <input type="text" id="callsign" name="callsign" class="form-control" value="{{ signup.callsign }}">
+  </div>
+  <div class="mb-3">
+    <label for="additional" class="form-label">Zusätzliche Personen</label>
+    <input type="number" id="additional" name="additional" class="form-control" min="0" max="5" value="{{ signup.additional }}">
+  </div>
+  <button type="submit" class="btn btn-primary">Speichern</button>
+  <a href="{{ url_for('admin') }}" class="btn btn-secondary">Abbrechen</a>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add routes to edit and delete signups
- show action buttons in the admin page
- add form template for editing a signup

## Testing
- `python -m py_compile app.py`
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`
- `python app.py &` (terminated immediately)

------
https://chatgpt.com/codex/tasks/task_e_686e81da5c9c8321b8ecf00dc79b3750