### PR TITLE
Add correction email hint after signup

### DIFF
--- a/app.py
+++ b/app.py
@@ -62,6 +62,7 @@ with app.app_context():
 @app.route('/', methods=['GET', 'POST'])
 def index():
     message = None
+    show_hint = False
     signup_allowed = date.today() < SIGNUP_DEADLINE
     if request.method == 'POST' and signup_allowed:
         name = request.form.get('name')
@@ -77,12 +78,14 @@ def index():
             db.session.add(signup)
             db.session.commit()
             message = f"Vielen Dank für deine Anmeldung für {signup.persons} Person{'en' if signup.persons != 1 else ''}!"
+            show_hint = True
         else:
             message = 'Name ist erforderlich.'
     elif request.method == 'POST' and not signup_allowed:
         message = 'Die Anmeldefrist ist abgelaufen.'
     total = total_persons()
-    return render_template('index.html', total_persons=total, message=message, signup_allowed=signup_allowed)
+    return render_template('index.html', total_persons=total, message=message,
+                           signup_allowed=signup_allowed, show_hint=show_hint)
 
 @app.route('/admin')
 @requires_auth

--- a/templates/index.html
+++ b/templates/index.html
@@ -25,5 +25,8 @@
 {% endif %}
 {% if message %}
 <div class="alert alert-success mt-3">{{ message }}</div>
+{% if show_hint %}
+<p class="mt-2">Sollte irgendeine Angabe nicht stimmen, bitte umgehend eine kurze Email an <a href="mailto:do1ffe@darc.de">do1ffe@darc.de</a> mit den Änderungswünschen senden.</p>
+{% endif %}
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- show a hint under the success message to email changes
- pass a new `show_hint` flag from the index view

## Testing
- `python -m py_compile app.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686e83a8877883218812beb2f30e47d9