### PR TITLE
Bugfix: Flash-Nachrichten anzeigen

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -7,6 +7,13 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body class="container my-4">
+  {% with messages = get_flashed_messages() %}
+    {% if messages %}
+      {% for message in messages %}
+        <div class="alert alert-success">{{ message }}</div>
+      {% endfor %}
+    {% endif %}
+  {% endwith %}
   {% block content %}{% endblock %}
   <footer class="text-center mt-4">
     <p>&copy; {{ current_year }} - Erik Schauer - <a href="mailto:do1ffe@darc.de">do1ffe@darc.de</a></p>

--- a/templates/index.html
+++ b/templates/index.html
@@ -24,14 +24,7 @@
 {% if not signup_allowed %}
 <div class="alert alert-warning mt-3">Die Anmeldung ist geschlossen.</div>
 {% endif %}
-{% with messages = get_flashed_messages() %}
-  {% if messages %}
-    {% for message in messages %}
-      <div class="alert alert-success mt-3">{{ message }}</div>
-    {% endfor %}
-    {% if show_hint %}
-    <p class="mt-2">Sollte irgendeine Angabe nicht stimmen, bitte umgehend eine kurze Email an <a href="mailto:do1ffe@darc.de">do1ffe@darc.de</a> mit den Änderungswünschen senden.</p>
-    {% endif %}
-  {% endif %}
-{% endwith %}
+{% if show_hint %}
+<p class="mt-2">Sollte irgendeine Angabe nicht stimmen, bitte umgehend eine kurze Email an <a href="mailto:do1ffe@darc.de">do1ffe@darc.de</a> mit den Änderungswünschen senden.</p>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary
- zeige geflashte Hinweise zentral im Base-Template
- entferne doppelten Flash-Code auf der Startseite

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_686edf06687c832182f71607d53e3ae6